### PR TITLE
Use pending extensions when registerExtensions is used & collectPii

### DIFF
--- a/ACPCore/core/ACPCore.m
+++ b/ACPCore/core/ACPCore.m
@@ -81,7 +81,7 @@ static NSMutableArray *_pendingExtensions;
 #pragma mark - Extensions
 
 + (void) registerExtensions: (NSArray* __nullable) extensions callback:(nullable void (^) (void)) callback {
-    NSMutableArray *cleanedExtensions = [NSMutableArray array];
+    NSMutableArray *cleanedExtensions = [NSMutableArray arrayWithArray:_pendingExtensions];
     for (id extensionClass in extensions) {
         Class wrappedExtension = [self wrapExtensionClassIfNeeded:extensionClass];
         if (wrappedExtension) {
@@ -90,6 +90,7 @@ static NSMutableArray *_pendingExtensions;
     }
     
     [AEPMobileCore registerExtensions:cleanedExtensions completion:callback];
+    [_pendingExtensions removeAllObjects];
 }
 
 + (BOOL) registerExtension: (nonnull Class) extensionClass
@@ -118,7 +119,7 @@ static NSMutableArray *_pendingExtensions;
 
 #pragma mark - Generic Methods
 + (void) collectPii: (nonnull NSDictionary<NSString*, NSString*>*) data {
-    // TODO
+    [AEPMobileCore collectPii:data];
 }
 
 + (void) lifecyclePause {

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -41,22 +41,22 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   AEPCore:
-    :commit: fe6ea7b92d2affa6d8b84d1981a6a6c37f191e47
+    :commit: eb72960eb84d5999f6674e81ed175ce845595d7f
     :git: "git@github.com:adobe/aepsdk-core-ios.git"
   AEPIdentity:
-    :commit: fe6ea7b92d2affa6d8b84d1981a6a6c37f191e47
+    :commit: eb72960eb84d5999f6674e81ed175ce845595d7f
     :git: "git@github.com:adobe/aepsdk-core-ios.git"
   AEPLifecycle:
-    :commit: fe6ea7b92d2affa6d8b84d1981a6a6c37f191e47
+    :commit: eb72960eb84d5999f6674e81ed175ce845595d7f
     :git: "git@github.com:adobe/aepsdk-core-ios.git"
   AEPRulesEngine:
     :commit: b7e2b7d778b07be8fccd6641e8119767bfc26b1f
     :git: "git@github.com:adobe/aepsdk-rulesengine-ios.git"
   AEPServices:
-    :commit: fe6ea7b92d2affa6d8b84d1981a6a6c37f191e47
+    :commit: eb72960eb84d5999f6674e81ed175ce845595d7f
     :git: "git@github.com:adobe/aepsdk-core-ios.git"
   AEPSignal:
-    :commit: fe6ea7b92d2affa6d8b84d1981a6a6c37f191e47
+    :commit: eb72960eb84d5999f6674e81ed175ce845595d7f
     :git: "git@github.com:adobe/aepsdk-core-ios.git"
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
This is to allow the following workflow:
```swift
AEPAssurance.registerExtension()
ACPCore.registerExtensions([Identity.self, Lifecycle.self, ExperiencePlatform.self])
```